### PR TITLE
Ab#27147: Updated CP3 API documentation for OPA Subjects endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The CentrePoint API uses [OAuth 2.0](https://oauth.net/2/) for its authorization
 #### Export DataSet Files
 
 * Access to DataSet Export files for a particular Study Id, Study Program combination. (see [DataSet Export Files](./sections/data_set_files.md))
+* Access to DataSet Export subjects for a particular Study Id. (see [DataSet Export Subjects](./sections/data_set_export_subjects.md))
 
 #### Analytics/Algorithmic Data-Retrieval
 

--- a/sections/data_set_export_subjects.md
+++ b/sections/data_set_export_subjects.md
@@ -1,0 +1,119 @@
+# DataSet Export Subjects
+
+**NOTE: These requests require the *DataAccess* API scope. (see [Scopes](scopes.md))**
+
+## Query Subjects
+
+**Request:**
+
+```http
+GET /studies/{studyId}/subjects
+```
+
+**Body Parameters:**
+No body parameters are required.
+
+**Response:**
+
+This response is paginated. See [Pagination](pagination.md) for a description of pagination related fields returned.
+
+|Field|Type|Description|
+|-----|----|-----------|
+|studyId|Number|CentrePoint Study ID (see [Studies](studies.md))|
+|subjectId|Number|CentrePoint Subject ID (see [Subjects](subjects.md))|
+|lastRawUploadedTimeStamp|DateTimeOffset|Last Raw Data Uploaded Timestamp|
+|studyProgramExecutions|List|List of all the programs that were executed for the subject|
+
+The study program executions will have following fields.
+
+|Field|Type|Description|
+|-----|----|-----------|
+|studyProgramId|Guid|Study Program Id of a particular program|
+|studyProgramName|String|Study Program Name of a particular program|
+|lastSuccessfulProgramExecutionTimeStamp|DateTimeOffset|Last Raw Data Uploaded Timestamp|
+
+```examples
+/studies/234/subjects
+```
+
+```json
+{
+    "items": [
+        {
+            "studyId": 234,
+            "subjectId": 10820,
+            "lastRawUploadedTimeStamp": "2024-03-07T09:27:02.6983354+00:00",
+            "studyProgramExecutions": [
+                {
+                    "studyProgramId": "1f08d07a-a507-47df-bc89-09412ae42352",
+                    "studyProgramName": "LeapBarometer (17)",
+                    "lastSuccessfulProgramExecutionTimeStamp": "0001-01-01T00:00:00+00:00"
+                }
+            ]
+        },
+        {
+            "studyId": 234,
+            "subjectId": 10821,
+            "lastRawUploadedTimeStamp": "0001-01-01T00:00:00+00:00",
+            "studyProgramExecutions": [
+                {
+                    "studyProgramId": "5b342a11-2fb9-4ad9-a7be-4d410181f51c",
+                    "studyProgramName": "Activity (30)",
+                    "lastSuccessfulProgramExecutionTimeStamp": "2024-03-07T06:58:03.6743755+00:00"
+                }
+            ]
+        }
+    ],
+    "links": {},
+    "totalCount": 2,
+    "limit": 100,
+    "offset": 0
+}
+```
+
+## Query Subject Details
+
+**Request:**
+
+```http
+GET /studies/{studyId}/subjects/{subjectId}
+```
+
+**Body Parameters:**
+No body parameters are required.
+
+**Response:**
+
+|Field|Type|Description|
+|-----|----|-----------|
+|studyId|Number|CentrePoint Study ID (see [Studies](studies.md))|
+|subjectId|Number|CentrePoint Subject ID (see [Subjects](subjects.md))|
+|lastRawUploadedTimeStamp|DateTimeOffset|Last Raw Data Uploaded Timestamp|
+|studyProgramExecutions|List|List of all the programs that were executed for the subject|
+
+The study program executions will have following fields.
+
+|Field|Type|Description|
+|-----|----|-----------|
+|studyProgramId|Guid|Study Program Id of a particular program|
+|studyProgramName|String|Study Program Name of a particular program|
+|lastSuccessfulProgramExecutionTimeStamp|DateTimeOffset|Last Raw Data Uploaded Timestamp|
+
+```examples
+/studies/234/subjects/10820
+```
+
+```json
+{
+    "studyId": 234,
+    "subjectId": 10820,
+    "lastRawUploadedTimeStamp": "2024-03-07T09:27:02.6983354+00:00",
+    "studyProgramExecutions": [
+        {
+            "studyProgramId": "1f08d07a-a507-47df-bc89-09412ae42352",
+            "studyProgramName": "LeapBarometer (17)",
+            "lastSuccessfulProgramExecutionTimeStamp": "2024-03-12T13:26:19.0936591+00:00"
+        }
+    ]
+}
+```

--- a/sections/data_set_export_subjects.md
+++ b/sections/data_set_export_subjects.md
@@ -30,7 +30,7 @@ The study program executions will have following fields.
 |-----|----|-----------|
 |studyProgramId|Guid|Study Program Id of a particular program|
 |studyProgramName|String|Study Program Name of a particular program|
-|lastSuccessfulProgramExecutionTimeStamp|DateTimeOffset|Last Raw Data Uploaded Timestamp|
+|lastSuccessfulProgramExecutionTimeStamp|DateTimeOffset|Timestamp when the program was successfully exscuted for the subject|
 
 ```examples
 /studies/234/subjects
@@ -97,7 +97,7 @@ The study program executions will have following fields.
 |-----|----|-----------|
 |studyProgramId|Guid|Study Program Id of a particular program|
 |studyProgramName|String|Study Program Name of a particular program|
-|lastSuccessfulProgramExecutionTimeStamp|DateTimeOffset|Last Raw Data Uploaded Timestamp|
+|lastSuccessfulProgramExecutionTimeStamp|DateTimeOffset|Timestamp when the program was successfully exscuted for the subject|
 
 ```examples
 /studies/234/subjects/10820


### PR DESCRIPTION
Ab#27147, Ab#53326

## Changes Made
- Updated CP3 API documentation for OPA Subjects endpoint.

![image](https://github.com/actigraph/CentrePoint3APIDocumentation/assets/103948128/48d7b2dc-2e42-46fc-bcc2-34d158b34de9)

Refer this [link](https://github.com/actigraph/CentrePoint3APIDocumentation/blob/ab53817-subject-endpoin-documentation/sections/data_set_export_subjects.md) to check the details about the subject endpoint.